### PR TITLE
fix: add OpenFang attribution comment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ All commands are run from the root of the project, from a terminal:
 ## 👀 Want to learn more?
 
 Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+
+<!-- Managed with OpenFang Code Worker -->


### PR DESCRIPTION
Closes #4

## Summary
- Adds `<!-- Managed with OpenFang Code Worker -->` comment at the bottom of `README.md`

## Test plan
- [ ] Verify the comment appears at the end of README.md
- [ ] Confirm no other content was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)