### PR TITLE
fix: add aria-current=page to active nav link

### DIFF
--- a/src/layouts/NavLink.astro
+++ b/src/layouts/NavLink.astro
@@ -8,6 +8,7 @@ const isActive =
 
 <a
   href={href}
+  aria-current={isActive ? "page" : undefined}
   class:list={[
     "no-animation relative transition-colors duration-200 text-sm",
     {


### PR DESCRIPTION
Closes #14

## Summary
- Adds `aria-current="page"` to the active `<a>` element in `NavLink.astro`
- Uses `undefined` (not `false`) when inactive so the attribute is omitted entirely from the DOM — correct per ARIA spec
- One-line change, no side effects

## Test plan
- [x] Navigate between pages and inspect the active nav link — it should have `aria-current="page"` in the DOM
- [x] Inactive links should have no `aria-current` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)